### PR TITLE
db8: Add outbound permissions for configurator, lunasend and monitor …

### DIFF
--- a/files/sysbus/dynamic/com.palm.db.role.json.in
+++ b/files/sysbus/dynamic/com.palm.db.role.json.in
@@ -5,15 +5,15 @@
     "permissions": [
         {
             "service":"com.palm.db",
-            "outbound":["com.webos.service.activitymanager.client","com.palm.service.backup","com.palm.systemmanager","com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.service.backup", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "com.webos.lunasend-*", "com.webos.monitor"]
         },
         {
             "service":"com.palm.tempdb",
-            "outbound":["com.webos.service.activitymanager.client","com.palm.activitymanager","com.palm.systemmanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "com.webos.lunasend-*", "com.webos.monitor"]
         },
         {
             "service":"com.webos.mediadb",
-            "outbound":["com.webos.service.activitymanager.client","com.palm.activitymanager","com.palm.systemmanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "com.webos.lunasend-*", "com.webos.monitor"]
         }
     ]
 }


### PR DESCRIPTION
…to db, tempdb and mediadb

Solves various errors such as:

Jun 15 14:57:50 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.configurator","SRC_APP_ID":"com.palm.tempdb","EXE":"/usr/sbin/mojodb-luna","PID":467} "com.palm.tempdb" does not have sufficient outbound permissions to communicate with "com.palm.configurator" (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/tempdb.conf)

Jun 15 15:44:29 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.lunasend-1692","SRC_APP_ID":"com.palm.tempdb","EXE":"/usr/sbin/mojodb-luna","PID":467} "com.palm.tempdb" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-1692" (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/tempdb.conf)

Jun 15 15:20:40 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.monitor","SRC_APP_ID":"com.palm.db","EXE":"/usr/sbin/mojodb-luna","PID":503} "com.palm.db" does not have sufficient outbound permissions to communicate with "com.webos.monitor" (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/maindb.conf)

Jun 15 15:40:59 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.lunasend-1644","SRC_APP_ID":"com.palm.db","EXE":"/usr/sbin/mojodb-luna","PID":503} "com.palm.db" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-1644" (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/maindb.conf)

Jun 15 15:20:40 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.monitor","SRC_APP_ID":"com.webos.mediadb","EXE":"/usr/sbin/mojodb-luna","PID":496} "com.webos.mediadb" does not have sufficient outbound permissions to communicate with "com.webos.monitor" (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/mediadb.conf)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>